### PR TITLE
Route Bootcamp and Hacklytics tabs to external sites

### DIFF
--- a/frontend/src/components/Navigation/index.js
+++ b/frontend/src/components/Navigation/index.js
@@ -125,8 +125,11 @@ class Navigation extends React.Component {
             <Nav.Link href={ROUTES.OUR_WORK} className="links">
               Our Work
             </Nav.Link>*/}
-            <Nav.Link href={ROUTES.BOOTCAMP} className="links">
+            <Nav.Link href={"https://dsgtbootcamp.netlify.app/"}className="links">
               Bootcamp
+            </Nav.Link>
+            <Nav.Link href={"https://hacklytics.io/"}className="links">
+              Hacklytics 
             </Nav.Link>
             <Nav.Link href={ROUTES.PROJECTS} className="links">
               Projects


### PR DESCRIPTION
Route the Bootcamp navbar tab to external bootcamp site. Create new navbar tab Hacklytics and route to external site. 


<img width="683" alt="Screen Shot 2021-10-15 at 9 13 19 AM" src="https://user-images.githubusercontent.com/65079595/137501643-7663956e-3983-4afd-bcfc-28d0d8064b8d.png">
e.